### PR TITLE
Add price field to comic component

### DIFF
--- a/client/src/components/Comic.js
+++ b/client/src/components/Comic.js
@@ -23,6 +23,7 @@ export default function Comic({
           <div className="card-body">
             <h5 className="card-title">{comic.title}</h5>
             <p className="card-text">{comic.description}</p>
+            <p className="card-text">Price: {comic.description?.match(/[$]\d+[.]\d\d/) || 'Not Found'}</p>
             <div className="card-body">
               {addToFavorites && (
                 <a


### PR DESCRIPTION
This PR addresses Issue #9. I used a regular expression with the String.prototype.match() method as shown in MDN. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match

There are several other ways you could chose to perform this action. You could tease the data out on the backend endpoint for comics and add an explicit price field on the object you return from the endpoint. You could change you db model and then perform a change on the data in your db. I can help when that if you make the issue on the backend repo.